### PR TITLE
Parse date and time in intent parser. r=samgiles

### DIFF
--- a/app/js/lib/intent-parser.js
+++ b/app/js/lib/intent-parser.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import chrono from 'components/chrono';
+
 /*
 Examples of supported phrases:
 Remind me to pick Sasha from Santa Clara University at 5PM today.
@@ -132,7 +134,10 @@ export default class IntentParser {
   }
 
   [p.parseDatetime](string = '') {
-    return string.trim();
+    string = string.trim();
+    const datetime = chrono.parseDate(string);
+
+    return datetime;
   }
 
   [p.normalise](string = '', locale = this.locale) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,12 +82,14 @@ gulp.task('copy-app-common', () => {
       .pipe(rename('js/alameda.js')),
 
     // Components.
+    gulp.src('./node_modules/jsspeechrecognizer/dist/JsSpeechRecognizer.js')
+      .pipe(rename('js/components/jsspeechrecognizer.js')),
     gulp.src('./node_modules/lodash/lodash.min.js')
       .pipe(rename('js/components/lodash.js')),
     gulp.src('./node_modules/moment/min/moment-with-locales.min.js')
       .pipe(rename('js/components/moment.js')),
-    gulp.src('./node_modules/jsspeechrecognizer/dist/JsSpeechRecognizer.js')
-      .pipe(rename('js/components/jsspeechrecognizer.js')),
+    gulp.src('./node_modules/chrono-node/chrono.min.js')
+      .pipe(rename('js/components/chrono.js')),
 
     // Polyfills.
     gulp.src('./node_modules/whatwg-fetch/fetch.js')

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MPL2",
   "dependencies": {
     "alameda": "^1.0.0",
+    "chrono-node": "^1.2.3",
     "jsspeechrecognizer": "https://github.com/samgiles/JsSpeechRecognizer.git",
     "lodash": "^4.13.1",
     "moment": "^2.13.0",


### PR DESCRIPTION
This patch uses `chrono` to parse dates and time in the intent parser.

@samgiles: can you review it?
