### PR TITLE
On speech recognition failure, restart the wakelisten after emitting an event r=gmarty

### DIFF
--- a/app/js/lib/speech-controller.js
+++ b/app/js/lib/speech-controller.js
@@ -79,6 +79,7 @@ export default class SpeechController extends EventDispatcher {
       .catch((err) => {
         console.log('startSpeechRecognition err', err);
         this.emit(EVENT_INTERFACE[4], { type: EVENT_INTERFACE[4] });
+        this.stopSpeechRecognition();
       });
   }
 


### PR DESCRIPTION
On the Sony tablet, the speech recognition fails with a network error causing the app to become unresponsive to the wakeword.  This makes sure the speech recognition is completely halted, and the speech controller restarted.

r? @gmarty 
