### PR TITLE
Implement a refiner for querying reminders. r=samgiles

### DIFF
--- a/app/js/lib/intent-parser/parsers/users-parser.js
+++ b/app/js/lib/intent-parser/parsers/users-parser.js
@@ -3,7 +3,13 @@ const PATTERNS = {
     patterns: [
       /^Remind (.+?) (?:to|at|on|by|that|about)\b/i,
       /^Where (?:am|are|is) (.+?) (?:at|on|by)\b/i,
+      /^Where (?:am|are|is) (.+?) supposed to\b/i,
+      /^Where should (.+?) go\b/i,
       /^What (?:am|are|is) (.+?) doing\b/i,
+      /^What (?:am|are|is) (.+?) supposed to\b/i,
+      /^What should (.+?) do\b/i,
+      /^What (?:do|does) (.+?) do\b/i,
+      /^What is (.+?)(?:'s)? (?:schedule|planning|calendar|agenda)\b/i,
       /([^ ]+ (?:and|&) [^ ]+)/i, // @todo Improve with more patterns.
     ],
     // @see http://www.unicode.org/cldr/charts/29/summary/en.html#6402

--- a/app/js/lib/intent-parser/refiners/confirmations/query-confirmation.js
+++ b/app/js/lib/intent-parser/refiners/confirmations/query-confirmation.js
@@ -4,20 +4,13 @@ import moment from 'components/moment';
 import 'components/cldr/en';
 import 'components/cldr/core';
 
-/*
- * @todo:
- *   * @see http://www.unicode.org/cldr/charts/29/verify/dates/en.html
- *     for formatting the time of the day.
- */
-
 const p = Object.freeze({
   // Properties
+  time: Symbol('time'),
+  users: Symbol('users'),
   listFormatter: Symbol('listFormatter'),
 
   // Methods
-  getLocalised: Symbol('getLocalised'),
-  formatUser: Symbol('formatUser'),
-  formatAction: Symbol('formatAction'),
   formatTime: Symbol('formatTime'),
   isToday: Symbol('isToday'),
   isTomorrow: Symbol('isTomorrow'),
@@ -25,10 +18,8 @@ const p = Object.freeze({
   formatHoursAndMinutes: Symbol('formatHoursAndMinutes'),
 });
 
-const DEFAULT_LOCALE = 'en';
 const PATTERNS = {
   en: {
-    template: `OK, I'll remind [users] [action] [time].`,
     formatUser: (user) => user
       .replace(/\bme\b/gi, 'you')
       .replace(/\bI am\b/gi, 'you are')
@@ -39,99 +30,61 @@ const PATTERNS = {
       .replace(/\bmine\b/gi, 'yours'),
   },
   fr: {
-    template: `OK, je rappelerai [users] [action] [time].`,
     formatUser: (user) => user,
   },
   ja: {
-    template: `承知しました。[time][users]に[action]をリマインドします。`,
     formatUser: (user) => user,
   },
 };
 
-export default class ReminderConfirmation {
-  constructor(locale = DEFAULT_LOCALE) {
-    this.locale = locale;
-
+export default class QueryConfirmation {
+  constructor({ due, recipients }) {
     TwitterCldr.set_data(TwitterCldrDataBundle);
     this[p.listFormatter] = new TwitterCldr.ListFormatter();
+
+    this[p.time] = due;
+    this[p.users] = recipients;
   }
 
-  /**
-   * Generate a phrase to be spoken to confirm a reminder.
-   *
-   * @param {Object} reminder
-   * @return {string}
-   */
   confirm(reminder) {
-    const template = this[p.getLocalised]('template');
-    const data = {
-      users: this[p.formatUser](reminder),
-      action: this[p.formatAction](reminder),
-      time: this[p.formatTime](reminder),
-    };
+    // We use the users from the original query rather than the found reminder.
+    const users = this[p.formatUser](this[p.users]);
 
-    return template.replace(/\[([^\]]+)\]/g, (match, placeholder) => {
-      return data[placeholder];
-    });
-  }
-
-  /**
-   * Given a property of the PATTERNS object, returns the one matching the
-   * current locale or the default one if non existing.
-   *
-   * @param {string} prop
-   * @returns {*}
-   */
-  [p.getLocalised](prop) {
-    let locale = this.locale;
-    if (!PATTERNS[this.locale] || !PATTERNS[this.locale][prop]) {
-      locale = DEFAULT_LOCALE;
+    if (!reminder) {
+      const time = this[p.formatTime]({ due: this[p.time] });
+      return `I can't find anything scheduled for ${users} ${time}.`;
     }
 
-    return PATTERNS[locale][prop];
+    const action = reminder.action;
+    const time = this[p.formatTime](reminder);
+
+    if (users === 'you' || this[p.users].length >= 1) {
+      return `${time}, ${users} have the following activity: "${action}".`;
+    }
+
+    return `${time}, ${users} has the following activity: "${action}".`;
   }
 
-  [p.formatUser]({ recipients }) {
-    const formatUser = this[p.getLocalised]('formatUser');
-    const formattedUsers = recipients.map(formatUser);
+  [p.formatUser](users) {
+    const formattedUsers = users.map(PATTERNS.en.formatUser);
     return this[p.listFormatter].format(formattedUsers);
   }
 
-  [p.formatAction]({ action, cleaned }) {
-    const formatUser = this[p.getLocalised]('formatUser');
-    const formattedAction = formatUser(action);
-
-    const PATTERN1 = new RegExp(`\\bthat ${action}`, 'iu');
-    const PATTERN2 = new RegExp(`\\bit is ${action}`, 'iu');
-    const PATTERN3 = new RegExp(`\\bthere is ${action}`, 'iu');
-    const PATTERN4 = new RegExp(`\\babout ${action}`, 'iu');
-
-    if (PATTERN1.test(cleaned)) {
-      return `that ${formattedAction}`;
-    } else if (PATTERN2.test(cleaned)) {
-      return `that it is ${formattedAction}`;
-    } else if (PATTERN3.test(cleaned)) {
-      return `that there is ${formattedAction}`;
-    } else if (PATTERN4.test(cleaned)) {
-      return `about ${formattedAction}`;
-    }
-
-    return `to ${formattedAction}`;
-  }
-
   [p.formatTime]({ due }) {
+    const hour = this[p.formatHoursAndMinutes](due);
+
     if (this[p.isToday](due)) {
-      const hour = this[p.formatHoursAndMinutes](due);
       return `at ${hour} today`;
     } else if (this[p.isTomorrow](due)) {
-      const hour = this[p.formatHoursAndMinutes](due);
       return `at ${hour} tomorrow`;
       // @todo Add a pattern here with the weekday if within 7 days.
     } else if (this[p.isThisMonth](due)) {
-      return moment(due).format('[on the] Do');
+      const day = moment(due).format('Do');
+      return `at ${hour} on the ${day}`;
     }
 
-    return moment(due).format('[on] MMMM [the] Do');
+    const day = moment(due).format('MMMM [the] Do');
+    return `at ${hour} on ${day}`;
   }
 
   [p.isToday](date) {

--- a/app/js/lib/intent-parser/refiners/query-refiner.js
+++ b/app/js/lib/intent-parser/refiners/query-refiner.js
@@ -1,3 +1,20 @@
+import QueryConfirmation from './confirmations/query-confirmation';
+
+const PATTERNS = {
+  en: {
+    formatUser: (user) => user
+      .replace(/\bI\b/gi, 'me')
+      .replace(/\bmy\b/gi, 'me')
+      .replace(/\bmine\b/gi, 'me'),
+  },
+  fr: {
+    formatUser: (user) => user,
+  },
+  ja: {
+    formatUser: (user) => user,
+  },
+};
+
 // @todo Handle the case where a time range is specified.
 export default class QueryRefiner {
   /**
@@ -19,11 +36,18 @@ export default class QueryRefiner {
       && obj.recipients.length > 0;
     const hasNoActions = obj.action === null;
 
-    if (obj.cleaned.match(/^(?:What|Where)/i)
+    if (obj.cleaned.match(/^(?:What|Where|When)/i)
       && hasTime
       && hasUsers
       && hasNoActions) {
+      const queryConfirmation = new QueryConfirmation({
+        due: obj.time[0].start,
+        recipients: obj.recipients,
+      });
+
       obj.due = obj.time[0].start;
+      obj.recipients = obj.recipients.map(PATTERNS.en.formatUser);
+      obj.confirmation = queryConfirmation.confirm.bind(queryConfirmation);
       obj.intent = 'query';
     }
 

--- a/tests/unit/lib/intent-parser/index_test.js
+++ b/tests/unit/lib/intent-parser/index_test.js
@@ -44,7 +44,7 @@ describe('intent-parser', function() {
         parsed: {
           recipients: ['Sandra'],
           action: null,
-          confirmation: undefined,
+          confirmation: () => {},
           // Always next Wednesday.
           due: moment({ hour: 22 }).day(3).isBefore(moment({ hour: 22 })) ?
             moment({ hour: 22 }).day(10).toDate().getTime() :
@@ -61,7 +61,11 @@ describe('intent-parser', function() {
         return intentParser.parse(sentence).then((result) => {
           assert.deepEqual(result.recipients, parsed.recipients);
           assert.equal(result.action, parsed.action);
-          assert.equal(result.confirmation, parsed.confirmation);
+          if (typeof parsed.confirmation === 'string') {
+            assert.equal(result.confirmation, parsed.confirmation);
+          } else {
+            assert.equal(typeof result.confirmation, 'function');
+          }
           assert.equal(result.due, parsed.due);
           assert.equal(result.intent, parsed.intent);
         });


### PR DESCRIPTION
This PR completes the support for querying reminders.
Because the list of the reminders and the intent parser lib are totally decoupled, I had to return a function for the confirmation that takes null or a reminder as parameter. This really is a massive hack but that does the trick for now. In the future we should refactor it so that the intent parser holds a reference to all reminders.

How does it look?
